### PR TITLE
change git cloning command text

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WRFotron uses pre-built executables on ARC4 from CEMAC. Everything required is l
 
 1. Log into ARC4 and clone the WRFotron repo:  
 ```bash
-git clone git@github.com:wrfchem-leeds/WRFotron.git
+git clone https://github.com/wrfchem-leeds/WRFotron.git
 ```
 
 2. Load the availability of CEMAC modules:


### PR DESCRIPTION
did not work for me when I ran `git clone git@github.com:wrfchem-leeds/WRFotron.git`
I got this error: 
```bash
Cloning into 'WRFotron'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
```
I had to run `git clone https://github.com/wrfchem-leeds/WRFotron.git` instead